### PR TITLE
Bump OS 20230414

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20221201"
+BASE_OS_IMAGE="rancher/harvester-os:20230414"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
Harvester base OS needs to update.

**Solution:**
Bump OS image to [rancher/harvester-os:20230414](https://github.com/harvester/os2/releases/tag/20230414).

**Related Issue:**

**Test plan:**

**More info:**
```

-----File-----

These entries have been added to docker.io/rancher/harvester-os:20230413: None

These entries have been deleted from docker.io/rancher/harvester-os:20230413: None

These entries have been changed between docker.io/rancher/harvester-os:20230413 and docker.io/rancher/harvester-os:20230414:
FILE                                                                                                                                                                  SIZE1        SIZE2
/boot/initrd-5.14.21-150400.24.55-default                                                                                                                             85.9M        85.9M
/var/cache/luet/luet.db                                                                                                                                               128K         128K
/usr/lib/sysimage/rpm/rpmdb.sqlite-shm                                                                                                                                32K          32K
/var/log/YaST2/mkinitrd.log                                                                                                                                           5.9K         5.9K
/var/cache/luet/packages/7c/7cbb6a84b446604fb8ba7ab976c607944a499072e2d9ea5c5dd8cfd18acd7bbd025170e293746a230a17a8d799d648e8fad934664888a2c278bdc5e5208564f0-a        303B         303B
/var/cache/luet/packages/39/3975965bf9d98cdf86bd46a18af8e1ef25a7a7cece44e1374cf1724164329369fc23f2e44004535a37ec7040ecad23211876de79ecb849c1e5063d0d1a6bd2ec-a        303B         303B
/var/cache/luet/packages/43/43a5ef38e02fddd02840c1a42cbf7b1a9e500ac5ccf1a0cfc3da27e5b9d70b12a1aeca196891cd99f73076458fce13e44aacaebc2b665ecd890e7a1d9f4d99aa-a        303B         303B
/var/cache/luet/packages/53/53171626d53f13d265093b87cac9e4561a562268773d719cccdbce21b713192843e16d174ca041db3e6cc5b92b74d81eebf1617bcdd26e502853d95ed658222f-a        303B         303B
/var/cache/luet/packages/33/336fa9f82de713f8b5d323f46b8420a1c71800cc1658d384ad559aa22a935f2e3488b4c954479e71433e34f9e3aec4cde3a65f33643d710b588f2024de81efd7-a        303B         303B
/var/cache/luet/packages/af/afd0ddf405f66ac2d9c3d6784713d7f3965f8346ce6dad1ddc0c489e0fdf68fac710b31413be714a53d5ef53b6afd66a1b228e0d063e9abc92afb25e261c2b0d-a        303B         303B
/var/cache/luet/packages/bb/bb53c5f400dbe7566d6b57bd8b6f740982f60f60eb7695873c727ea9715e5ffcde5c2d0f94b959356e1b2fa0d6654b978acfdbc0d5594c2a6ee26667f435faca-a        303B         303B
/var/cache/luet/packages/cf/cfbbfaf8465749203d0df8cf274e7157bdc4aef197be46512522977f930b968512419a19798d116cd727af338a6d9a03ad9dd2abf76a1a6d1f726706e42e0f2c-a        303B         303B
/var/cache/luet/packages/e3/e3aa878dfcb1992bb4a885fd14100fece571c191c7c462112250f3df0e130bffa97ca1e110305fdb59b0d1260097e30c7fcfed006ff87f4f3a5da084a065d1f3-a        303B         303B
/var/log/pbl.log                                                                                                                                                      297B         297B
/usr/lib/os-release                                                                                                                                                   259B         259B
/var/cache/luet/repos/cos/SYNCTIME                                                                                                                                    20B          20B


-----RPM-----

Packages found only in docker.io/rancher/harvester-os:20230413: None

Packages found only in docker.io/rancher/harvester-os:20230414: None

Version differences: None

```